### PR TITLE
Add controller based broker selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,18 @@ Pinot client could be initialized through:
 1. Zookeeper Path.
 
 ```
-pinotClient := pinot.NewFromZookeeper([]string{"localhost:2123"}, "", "QuickStartCluster")
+pinotClient, err := pinot.NewFromZookeeper([]string{"localhost:2123"}, "", "QuickStartCluster")
 ```
 
-2. A list of broker addresses.
+2. Controller address.
+
+```
+pinotClient, err := pinot.NewFromController("localhost:9000")
+```
+
+When the controller-based broker selector is used, the client will periodically fetch the table-to-broker mapping from the controller API. When using `http` scheme, the `http://` controller address prefix is optional.
+
+3. A list of broker addresses.
 
 - For HTTP
   Default scheme is HTTP if not specified.
@@ -91,18 +99,41 @@ pinotClient, err := pinot.NewFromBrokerList([]string{"localhost:8000"})
 pinotClient, err := pinot.NewFromBrokerList([]string{"https://pinot-broker.pinot.live"})
 ```
 
-3. ClientConfig
+4. ClientConfig
+
+Via Zookeeper path:
 
 ```
-pinotClient := pinot.NewWithConfig(&pinot.ClientConfig{
+pinotClient, err := pinot.NewWithConfig(&pinot.ClientConfig{
 	ZkConfig: &pinot.ZookeeperConfig{
 		ZookeeperPath:     zkPath,
 		PathPrefix:        strings.Join([]string{zkPathPrefix, pinotCluster}, "/"),
 		SessionTimeoutSec: defaultZkSessionTimeoutSec,
 	},
+	// additional header added to Broker Query API requests
     ExtraHTTPHeader: map[string]string{
         "extra-header":"value",
     },
+})
+```
+
+Via controller address:
+
+```
+pinotClient, err := pinot.NewWithConfig(&pinot.ClientConfig{
+	ControllerConfig: &pinot.ControllerConfig{
+		ControllerAddress: "localhost:9000",
+		// Frequency of broker data refresh in milliseconds via controller API - defaults to 1000ms
+		UpdateFreqMs: 500,
+		// Additional HTTP headers to include in the controller API request
+		ExtraControllerAPIHeaders: map[string]string{
+			"header": "val",
+		},
+	},
+	// additional header added to Broker Query API requests
+	ExtraHTTPHeader: map[string]string{
+		"extra-header": "value",
+	},
 })
 ```
 

--- a/pinot/config.go
+++ b/pinot/config.go
@@ -3,7 +3,7 @@ package pinot
 // ClientConfig configs to create a PinotDbConnection
 type ClientConfig struct {
 
-	// Request header
+	// Additional HTTP headers to include in broker query API requests
 	ExtraHTTPHeader map[string]string
 
 	// Zookeeper Configs
@@ -11,6 +11,9 @@ type ClientConfig struct {
 
 	// BrokerList
 	BrokerList []string
+
+	// Controller Config
+	ControllerConfig *ControllerConfig
 }
 
 // ZookeeperConfig describes how to config Pinot Zookeeper connection
@@ -18,4 +21,14 @@ type ZookeeperConfig struct {
 	ZookeeperPath     []string
 	PathPrefix        string
 	SessionTimeoutSec int
+}
+
+// ControllerConfig describes connection of a controller-based selector that
+// periodically fetches table-to-broker mapping via the controller API
+type ControllerConfig struct {
+	ControllerAddress string
+	// Frequency of broker data refresh in milliseconds via controller API - defaults to 1000ms
+	UpdateFreqMs int
+	// Additional HTTP headers to include in the controller API request
+	ExtraControllerAPIHeaders map[string]string
 }

--- a/pinot/connectionFactory.go
+++ b/pinot/connectionFactory.go
@@ -32,14 +32,14 @@ func NewFromZookeeper(zkPath []string, zkPathPrefix string, pinotCluster string)
 
 // NewWithConfig create a new Pinot connection.
 func NewWithConfig(config *ClientConfig) (*Connection, error) {
-	tansport := &jsonAsyncHTTPClientTransport{
+	transport := &jsonAsyncHTTPClientTransport{
 		client: http.DefaultClient,
 		header: config.ExtraHTTPHeader,
 	}
 	var conn *Connection
 	if config.ZkConfig != nil {
 		conn = &Connection{
-			transport: tansport,
+			transport: transport,
 			brokerSelector: &dynamicBrokerSelector{
 				zkConfig: config.ZkConfig,
 			},
@@ -47,7 +47,7 @@ func NewWithConfig(config *ClientConfig) (*Connection, error) {
 	}
 	if config.BrokerList != nil && len(config.BrokerList) > 0 {
 		conn = &Connection{
-			transport: tansport,
+			transport: transport,
 			brokerSelector: &simpleBrokerSelector{
 				brokerList: config.BrokerList,
 			},

--- a/pinot/connectionFactory_test.go
+++ b/pinot/connectionFactory_test.go
@@ -27,4 +27,11 @@ func TestPinotClients(t *testing.T) {
 	assert.NotNil(t, pinotClient2.brokerSelector)
 	assert.NotNil(t, pinotClient2.transport)
 	assert.Nil(t, err)
+	pinotClient3, err := NewFromController("localhost:9000")
+	assert.NotNil(t, pinotClient3)
+	assert.NotNil(t, pinotClient3.brokerSelector)
+	assert.NotNil(t, pinotClient3.transport)
+	_, err = NewWithConfig(&ClientConfig{})
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "please specify"))
 }

--- a/pinot/controllerBasedBrokerSelector.go
+++ b/pinot/controllerBasedBrokerSelector.go
@@ -1,0 +1,136 @@
+package pinot
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	controllerAPIEndpoint = "/v2/brokers/tables?state=ONLINE"
+	defaultUpdateFreqMs   = 1000
+)
+
+var (
+	controllerDefaultHTTPHeader = map[string]string{
+		"Accept": "application/json",
+	}
+)
+
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+type controllerBasedSelector struct {
+	tableAwareBrokerSelector
+	controllerAPIReqUrl string
+	config              *ControllerConfig
+	client              HTTPClient
+}
+
+func (s *controllerBasedSelector) init() error {
+	if s.config.UpdateFreqMs == 0 {
+		s.config.UpdateFreqMs = defaultUpdateFreqMs
+	}
+	u, err := getControllerRequestUrl(s.config.ControllerAddress)
+	if err != nil {
+		log.Error(err)
+		return err
+	}
+	s.controllerAPIReqUrl = u
+
+	err = s.updateBrokerData()
+	if err != nil {
+		log.Errorf(
+			"An error occurred when fetching broker data from controller API for the first time, Error: %v",
+			err,
+		)
+		return err
+	}
+	go s.setupInterval()
+	return nil
+}
+
+func (s *controllerBasedSelector) setupInterval() {
+	lastInvocation := time.Now()
+	for {
+		nextInvocation := lastInvocation.Add(
+			time.Duration(s.config.UpdateFreqMs) * time.Millisecond,
+		)
+		untilNextInvocation := time.Until(nextInvocation)
+		time.Sleep(untilNextInvocation)
+
+		err := s.updateBrokerData()
+		if err != nil {
+			log.Errorf("Caught exception when updating broker data, Error: %v", err)
+		}
+
+		lastInvocation = time.Now()
+	}
+}
+
+func getControllerRequestUrl(controllerAddress string) (string, error) {
+	tokenized := strings.Split(controllerAddress, "://")
+	addressWithScheme := controllerAddress
+	if len(tokenized) > 1 {
+		scheme := tokenized[0]
+		if scheme != "https" && scheme != "http" {
+			return "", fmt.Errorf(
+				"Unsupported controller URL scheme: %s, only http (default) and https are allowed",
+				scheme,
+			)
+		}
+	} else {
+		addressWithScheme = "http://" + controllerAddress
+	}
+	return strings.TrimSuffix(addressWithScheme, "/") + controllerAPIEndpoint, nil
+}
+
+func (s *controllerBasedSelector) createControllerRequest() (*http.Request, error) {
+	r, err := http.NewRequest("GET", s.controllerAPIReqUrl, nil)
+	if err != nil {
+		return r, fmt.Errorf(
+			"Caught exception when creating controller API request: %v",
+			err,
+		)
+	}
+	for k, v := range controllerDefaultHTTPHeader {
+		r.Header.Add(k, v)
+	}
+	for k, v := range s.config.ExtraControllerAPIHeaders {
+		r.Header.Add(k, v)
+	}
+	return r, nil
+}
+
+func (s *controllerBasedSelector) updateBrokerData() error {
+	r, err := s.createControllerRequest()
+	if err != nil {
+		return err
+	}
+	resp, err := s.client.Do(r)
+	if err != nil {
+		return fmt.Errorf("Got exceptions while sending controller API request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("An error occurred when reading controller API response: %v", err)
+		}
+		var c controllerResponse
+		if err = decodeJsonWithNumber(bodyBytes, &c); err != nil {
+			return fmt.Errorf("An error occurred when decoding controller API response: %v", err)
+		}
+		s.rwMux.Lock()
+		s.allBrokerList = c.extractBrokerList()
+		s.tableBrokerMap = c.extractTableToBrokerMap()
+		s.rwMux.Unlock()
+		return nil
+	}
+	return fmt.Errorf("Controller API returned HTTP status code %v", resp.StatusCode)
+}

--- a/pinot/controllerBasedBrokerSelector_test.go
+++ b/pinot/controllerBasedBrokerSelector_test.go
@@ -1,0 +1,208 @@
+package pinot
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type MockHTTPClientSuccess struct {
+	statusCode int
+	body       io.ReadCloser
+}
+
+func (m *MockHTTPClientSuccess) Do(req *http.Request) (*http.Response, error) {
+	r := &http.Response{}
+	r.StatusCode = m.statusCode
+	r.Body = m.body
+	return r, nil
+}
+
+type MockHTTPClientFailure struct {
+	err error
+}
+
+func (m *MockHTTPClientFailure) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{}, m.err
+}
+
+func TestControllerBasedBrokerSelectorInit(t *testing.T) {
+	s := &controllerBasedSelector{
+		config: &ControllerConfig{
+			ControllerAddress: "localhost:9000",
+		},
+		client: &MockHTTPClientSuccess{
+			statusCode: 200,
+			body:       ioutil.NopCloser(strings.NewReader("{}")),
+		},
+	}
+	err := s.init()
+	assert.Nil(t, err)
+	assert.Equal(t, s.config.UpdateFreqMs, 1000)
+	assert.Equal(t, s.controllerAPIReqUrl, "http://localhost:9000/v2/brokers/tables?state=ONLINE")
+	assert.ElementsMatch(t, s.allBrokerList, []string{})
+}
+
+func TestControllerBasedBrokerSelectorInitError(t *testing.T) {
+	s := &controllerBasedSelector{
+		config: &ControllerConfig{
+			ControllerAddress: "https://host:9000",
+		},
+		client: &MockHTTPClientFailure{
+			err: errors.New("http client error"),
+		},
+	}
+	err := s.init()
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "http client error"))
+}
+
+func TestGetControllerRequestUrl(t *testing.T) {
+	u, err := getControllerRequestUrl("localhost:9000")
+	assert.Nil(t, err)
+	assert.Equal(t, "http://localhost:9000/v2/brokers/tables?state=ONLINE", u)
+
+	u, err = getControllerRequestUrl("https://host:1234")
+	assert.Nil(t, err)
+	assert.Equal(t, "https://host:1234/v2/brokers/tables?state=ONLINE", u)
+
+	u, err = getControllerRequestUrl("http://host:1234")
+	assert.Nil(t, err)
+	assert.Equal(t, "http://host:1234/v2/brokers/tables?state=ONLINE", u)
+
+	u, err = getControllerRequestUrl("smb://nope:1234")
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "Unsupported controller URL scheme: smb"))
+}
+
+func TestCreateControllerRequest(t *testing.T) {
+	s := &controllerBasedSelector{
+		config: &ControllerConfig{
+			ControllerAddress: "localhost:9000",
+			ExtraControllerAPIHeaders: map[string]string{
+				"foo1": "bar",
+				"foo2": "baz",
+			},
+		},
+	}
+	r, err := s.createControllerRequest()
+	assert.Nil(t, err)
+	assert.Equal(t, 3, len(r.Header))
+	assert.Equal(t, "bar", r.Header.Get("foo1"))
+}
+
+func TestUpdateBrokerData(t *testing.T) {
+	s := &controllerBasedSelector{
+		config: &ControllerConfig{
+			ControllerAddress: "localhost:9000",
+		},
+		client: &MockHTTPClientSuccess{
+			statusCode: 200,
+			body: ioutil.NopCloser(
+				strings.NewReader(
+					`{"baseballStats":[{"port":8000,"host":"172.17.0.2","instanceName":"Broker_172.17.0.2_8000"}]}`,
+				),
+			),
+		},
+	}
+	err := s.updateBrokerData()
+	expectedTableBrokerMap := map[string]([]string){
+		"baseballStats": {
+			"172.17.0.2:8000",
+		},
+	}
+	assert.Nil(t, err)
+	assert.ElementsMatch(t, s.allBrokerList, []string{"172.17.0.2:8000"})
+	assert.True(t, reflect.DeepEqual(s.tableBrokerMap, expectedTableBrokerMap))
+}
+
+func TestUpdateBrokerDataHTTPError(t *testing.T) {
+	s := &controllerBasedSelector{
+		config: &ControllerConfig{
+			ControllerAddress: "localhost:9000",
+		},
+		client: &MockHTTPClientFailure{
+			err: errors.New("http error"),
+		},
+	}
+	s.allBrokerList = []string{"broker1:8000", "broker2:8000"}
+	s.tableBrokerMap = map[string]([]string){
+		"table1": {
+			"broker1:8000",
+			"broker2:8000",
+		},
+	}
+	err := s.updateBrokerData()
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "http error"))
+	assert.ElementsMatch(t, s.allBrokerList, []string{"broker1:8000", "broker2:8000"})
+	assert.True(t, reflect.DeepEqual(s.tableBrokerMap, map[string]([]string){
+		"table1": {
+			"broker1:8000",
+			"broker2:8000",
+		},
+	}))
+}
+
+func TestUpdateBrokerDataDecodeError(t *testing.T) {
+	s := &controllerBasedSelector{
+		config: &ControllerConfig{
+			ControllerAddress: "localhost:9000",
+		},
+		client: &MockHTTPClientSuccess{
+			statusCode: 200,
+			body:       ioutil.NopCloser(strings.NewReader("{not a valid json")),
+		},
+	}
+	err := s.updateBrokerData()
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "decoding controller API response"))
+}
+
+type errReader int
+
+func (errReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("test read error")
+}
+
+func (errReader) Close() error {
+	return nil
+}
+
+func TestUpdateBrokerDataResponseReadError(t *testing.T) {
+	s := &controllerBasedSelector{
+		config: &ControllerConfig{
+			ControllerAddress: "localhost:9000",
+		},
+		client: &MockHTTPClientSuccess{
+			statusCode: 200,
+			body:       errReader(0),
+		},
+	}
+	err := s.updateBrokerData()
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "reading controller API response"))
+}
+
+func TestUpdateBrokerDataUnexpectedHTTPStatus(t *testing.T) {
+	s := &controllerBasedSelector{
+		config: &ControllerConfig{
+			ControllerAddress: "localhost:9000",
+		},
+		client: &MockHTTPClientSuccess{
+			statusCode: 500,
+			body:       ioutil.NopCloser(strings.NewReader("{}")),
+		},
+	}
+	err := s.updateBrokerData()
+	assert.NotNil(t, err)
+	fmt.Println(err.Error())
+	assert.True(t, strings.Contains(err.Error(), "returned HTTP status code 500"))
+}

--- a/pinot/controllerResponse.go
+++ b/pinot/controllerResponse.go
@@ -1,0 +1,45 @@
+package pinot
+
+import (
+	"strconv"
+	"strings"
+)
+
+type brokerDto struct {
+	Port         int    `json:"port"`
+	Host         string `json:"host"`
+	InstanceName string `json:"instanceName"`
+}
+
+type controllerResponse map[string]([]brokerDto)
+
+func (b *brokerDto) extractBrokerName() string {
+	return strings.Join([]string{b.Host, strconv.Itoa(b.Port)}, ":")
+}
+
+func (r *controllerResponse) extractBrokerList() []string {
+	brokerSet := map[string]struct{}{}
+	for _, brokers := range *r {
+		for _, broker := range brokers {
+			brokerSet[broker.extractBrokerName()] = struct{}{}
+		}
+	}
+	brokerList := make([]string, 0, len(brokerSet))
+
+	for key := range brokerSet {
+		brokerList = append(brokerList, key)
+	}
+	return brokerList
+}
+
+func (r *controllerResponse) extractTableToBrokerMap() map[string]([]string) {
+	tableToBrokerMap := make(map[string]([]string))
+	for table, brokers := range *r {
+		brokersPerTable := make([]string, 0, len(brokers))
+		for _, broker := range brokers {
+			brokersPerTable = append(brokersPerTable, broker.extractBrokerName())
+		}
+		tableToBrokerMap[table] = brokersPerTable
+	}
+	return tableToBrokerMap
+}

--- a/pinot/controllerResponse_test.go
+++ b/pinot/controllerResponse_test.go
@@ -1,0 +1,108 @@
+package pinot
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractBrokerName(t *testing.T) {
+	b := &brokerDto{
+		Port:         8000,
+		Host:         "testHost",
+		InstanceName: "Broker_testHost_8000",
+	}
+	name := b.extractBrokerName()
+	assert.Equal(t, "testHost:8000", name)
+}
+
+func TestExtractBrokerList(t *testing.T) {
+	r := &controllerResponse{
+		"table1": {
+			{
+
+				Port:         8000,
+				Host:         "testHost1",
+				InstanceName: "Broker_testHost1_8000",
+			},
+			{
+
+				Port:         8000,
+				Host:         "testHost2",
+				InstanceName: "Broker_testHost2_8000",
+			},
+		},
+		"table2": {
+			{
+
+				Port:         8000,
+				Host:         "testHost2",
+				InstanceName: "Broker_testHost2_8000",
+			},
+			{
+
+				Port:         8123,
+				Host:         "testHost3",
+				InstanceName: "Broker_testHost3_8123",
+			},
+		},
+	}
+	brokerList := r.extractBrokerList()
+	assert.ElementsMatch(
+		t,
+		[]string{"testHost1:8000", "testHost2:8000", "testHost3:8123"},
+		brokerList,
+	)
+}
+
+func TestExtractBrokerListEmpty(t *testing.T) {
+	r := &controllerResponse{}
+	brokerList := r.extractBrokerList()
+	assert.Len(t, brokerList, 0)
+}
+
+func TestExtractTableToBrokerMap(t *testing.T) {
+	r := &controllerResponse{
+		"table1": {
+			{
+
+				Port:         8000,
+				Host:         "testHost1",
+				InstanceName: "Broker_testHost1_8000",
+			},
+			{
+
+				Port:         8000,
+				Host:         "testHost2",
+				InstanceName: "Broker_testHost2_8000",
+			},
+		},
+		"table2": {
+			{
+
+				Port:         8000,
+				Host:         "testHost2",
+				InstanceName: "Broker_testHost2_8000",
+			},
+			{
+
+				Port:         8123,
+				Host:         "testHost3",
+				InstanceName: "Broker_testHost3_8123",
+			},
+		},
+	}
+	tableToBrokerMap := r.extractTableToBrokerMap()
+	expected := map[string]([]string){
+		"table1": {
+			"testHost1:8000",
+			"testHost2:8000",
+		},
+		"table2": {
+			"testHost2:8000",
+			"testHost3:8123",
+		},
+	}
+	assert.True(t, reflect.DeepEqual(tableToBrokerMap, expected))
+}

--- a/pinot/dynamicBrokerSelector.go
+++ b/pinot/dynamicBrokerSelector.go
@@ -49,7 +49,7 @@ func (s *dynamicBrokerSelector) init() error {
 	}
 	s.readZNode = func(path string) ([]byte, error) {
 		if s.zkConn == nil {
-			return nil, fmt.Errorf("Zk Connection hasn't been initailized.")
+			return nil, fmt.Errorf("Zk Connection hasn't been initialized.")
 		}
 		node, _, err := s.zkConn.Get(s.externalViewZkPath)
 		if err != nil {
@@ -134,7 +134,7 @@ func (s *dynamicBrokerSelector) selectBroker(table string) (string, error) {
 		brokerList = s.allBrokerList
 		s.rwMux.RUnlock()
 		if len(brokerList) == 0 {
-			return "", fmt.Errorf("No availble broker found")
+			return "", fmt.Errorf("No available broker found")
 		}
 	} else {
 		var found bool
@@ -145,7 +145,7 @@ func (s *dynamicBrokerSelector) selectBroker(table string) (string, error) {
 			return "", fmt.Errorf("Unable to find the table: %s", table)
 		}
 		if len(brokerList) == 0 {
-			return "", fmt.Errorf("No availble broker found for table: %s", table)
+			return "", fmt.Errorf("No available broker found for table: %s", table)
 		}
 	}
 	return brokerList[rand.Intn(len(brokerList))], nil

--- a/pinot/dynamicBrokerSelector.go
+++ b/pinot/dynamicBrokerSelector.go
@@ -3,10 +3,8 @@ package pinot
 import (
 	"encoding/json"
 	"fmt"
-	"math/rand"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	zk "github.com/samuel/go-zookeeper/zk"
@@ -16,20 +14,16 @@ import (
 
 const (
 	brokerExternalViewPath = "EXTERNALVIEW/brokerResource"
-	offlineSuffix          = "_OFFLINE"
-	realtimeSuffix         = "_REALTIME"
 )
 
 type ReadZNode func(path string) ([]byte, error)
 
 type dynamicBrokerSelector struct {
+	tableAwareBrokerSelector
 	zkConfig               *ZookeeperConfig
 	zkConn                 *zk.Conn
 	externalViewZnodeWatch <-chan zk.Event
 	readZNode              ReadZNode
-	tableBrokerMap         map[string]([]string)
-	allBrokerList          []string
-	rwMux                  sync.RWMutex
 	externalViewZkPath     string
 }
 
@@ -124,35 +118,6 @@ func generateNewBrokerMappingExternalView(ev *externalView) (map[string]([]strin
 		allBrokerList = append(allBrokerList, tableBrokerMap[tableName]...)
 	}
 	return tableBrokerMap, allBrokerList
-}
-
-func (s *dynamicBrokerSelector) selectBroker(table string) (string, error) {
-	tableName := extractTableName(table)
-	var brokerList []string
-	if tableName == "" {
-		s.rwMux.RLock()
-		brokerList = s.allBrokerList
-		s.rwMux.RUnlock()
-		if len(brokerList) == 0 {
-			return "", fmt.Errorf("No available broker found")
-		}
-	} else {
-		var found bool
-		s.rwMux.RLock()
-		brokerList, found = s.tableBrokerMap[tableName]
-		s.rwMux.RUnlock()
-		if !found {
-			return "", fmt.Errorf("Unable to find the table: %s", table)
-		}
-		if len(brokerList) == 0 {
-			return "", fmt.Errorf("No available broker found for table: %s", table)
-		}
-	}
-	return brokerList[rand.Intn(len(brokerList))], nil
-}
-
-func extractTableName(table string) string {
-	return strings.Replace(strings.Replace(table, offlineSuffix, "", 1), realtimeSuffix, "", 1)
 }
 
 func extractBrokers(brokerMap map[string]string) []string {

--- a/pinot/dynamicBrokerSelector_test.go
+++ b/pinot/dynamicBrokerSelector_test.go
@@ -9,12 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExtractTableName(t *testing.T) {
-	assert.Equal(t, "table", extractTableName("table_OFFLINE"))
-	assert.Equal(t, "table", extractTableName("table_REALTIME"))
-	assert.Equal(t, "table", extractTableName("table"))
-}
-
 func TestExtractBrokers(t *testing.T) {
 	brokers := extractBrokers(map[string]string{
 		"BROKER_broker-1_1000": "ONLINE",
@@ -38,10 +32,12 @@ func TestExtractBrokerHostPort(t *testing.T) {
 
 func TestErrorInit(t *testing.T) {
 	selector := &dynamicBrokerSelector{
+		tableAwareBrokerSelector: tableAwareBrokerSelector{
+			tableBrokerMap: map[string]([]string){"myTable": []string{}},
+		},
 		zkConfig: &ZookeeperConfig{
 			ZookeeperPath: []string{},
 		},
-		tableBrokerMap: map[string]([]string){"myTable": []string{}},
 	}
 	err := selector.init()
 	assert.NotNil(t, err)
@@ -49,39 +45,14 @@ func TestErrorInit(t *testing.T) {
 
 func TestErrorRefreshExternalView(t *testing.T) {
 	selector := &dynamicBrokerSelector{
+		tableAwareBrokerSelector: tableAwareBrokerSelector{
+			tableBrokerMap: map[string]([]string){"myTable": []string{}},
+		},
 		zkConfig: &ZookeeperConfig{
 			ZookeeperPath: []string{},
 		},
-		tableBrokerMap: map[string]([]string){"myTable": []string{}},
 	}
 	err := selector.refreshExternalView()
-	assert.NotNil(t, err)
-}
-
-func TestSelectBroker(t *testing.T) {
-	selector := &dynamicBrokerSelector{
-		tableBrokerMap: map[string]([]string){"myTable": []string{"localhost:8000"}},
-		allBrokerList:  []string{"localhost:8000"},
-	}
-	broker, err := selector.selectBroker("")
-	assert.Equal(t, "localhost:8000", broker)
-	assert.Nil(t, err)
-	broker, err = selector.selectBroker("myTable")
-	assert.Equal(t, "localhost:8000", broker)
-	assert.Nil(t, err)
-	_, err = selector.selectBroker("unexistTable")
-	assert.NotNil(t, err)
-}
-
-func TestErrorSelectBroker(t *testing.T) {
-	emptySelector := &dynamicBrokerSelector{
-		tableBrokerMap: map[string]([]string){"myTable": []string{}},
-	}
-	_, err := emptySelector.selectBroker("")
-	assert.NotNil(t, err)
-	_, err = emptySelector.selectBroker("myTable")
-	assert.NotNil(t, err)
-	_, err = emptySelector.selectBroker("unexistTable")
 	assert.NotNil(t, err)
 }
 

--- a/pinot/tableAwareBrokerSelector.go
+++ b/pinot/tableAwareBrokerSelector.go
@@ -1,0 +1,48 @@
+package pinot
+
+import (
+	"fmt"
+	"math/rand"
+	"strings"
+	"sync"
+)
+
+const (
+	offlineSuffix  = "_OFFLINE"
+	realtimeSuffix = "_REALTIME"
+)
+
+type tableAwareBrokerSelector struct {
+	tableBrokerMap map[string]([]string)
+	allBrokerList  []string
+	rwMux          sync.RWMutex
+}
+
+func (s *tableAwareBrokerSelector) selectBroker(table string) (string, error) {
+	tableName := extractTableName(table)
+	var brokerList []string
+	if tableName == "" {
+		s.rwMux.RLock()
+		brokerList = s.allBrokerList
+		s.rwMux.RUnlock()
+		if len(brokerList) == 0 {
+			return "", fmt.Errorf("No available broker found")
+		}
+	} else {
+		var found bool
+		s.rwMux.RLock()
+		brokerList, found = s.tableBrokerMap[tableName]
+		s.rwMux.RUnlock()
+		if !found {
+			return "", fmt.Errorf("Unable to find the table: %s", table)
+		}
+		if len(brokerList) == 0 {
+			return "", fmt.Errorf("No available broker found for table: %s", table)
+		}
+	}
+	return brokerList[rand.Intn(len(brokerList))], nil
+}
+
+func extractTableName(table string) string {
+	return strings.Replace(strings.Replace(table, offlineSuffix, "", 1), realtimeSuffix, "", 1)
+}

--- a/pinot/tableAwareBrokerSelector_test.go
+++ b/pinot/tableAwareBrokerSelector_test.go
@@ -1,0 +1,40 @@
+package pinot
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractTableName(t *testing.T) {
+	assert.Equal(t, "table", extractTableName("table_OFFLINE"))
+	assert.Equal(t, "table", extractTableName("table_REALTIME"))
+	assert.Equal(t, "table", extractTableName("table"))
+}
+
+func TestSelectBroker(t *testing.T) {
+	selector := &tableAwareBrokerSelector{
+		tableBrokerMap: map[string]([]string){"myTable": []string{"localhost:8000"}},
+		allBrokerList:  []string{"localhost:8000"},
+	}
+	broker, err := selector.selectBroker("")
+	assert.Equal(t, "localhost:8000", broker)
+	assert.Nil(t, err)
+	broker, err = selector.selectBroker("myTable")
+	assert.Equal(t, "localhost:8000", broker)
+	assert.Nil(t, err)
+	_, err = selector.selectBroker("unexistTable")
+	assert.NotNil(t, err)
+}
+
+func TestErrorSelectBroker(t *testing.T) {
+	emptySelector := &tableAwareBrokerSelector{
+		tableBrokerMap: map[string]([]string){"myTable": []string{}},
+	}
+	_, err := emptySelector.selectBroker("")
+	assert.NotNil(t, err)
+	_, err = emptySelector.selectBroker("myTable")
+	assert.NotNil(t, err)
+	_, err = emptySelector.selectBroker("unexistTable")
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
This PR adds a controller based broker selector that periodically fetches broker-to-table mapping from the Controller API (`/v2/brokers/tables?state=ONLINE`).

Similar functionality is already implemented in the Java client (apache/pinot#8467).