### PR TITLE
Deprecate PQL query endpoint

### DIFF
--- a/examples/pinot-live-demo/main.go
+++ b/examples/pinot-live-demo/main.go
@@ -32,16 +32,6 @@ func main() {
 		}
 		printBrokerResp(brokerResp)
 	}
-
-	log.Infof("Querying PQL")
-	for _, query := range pinotQueries {
-		log.Infof("Trying to query Pinot: %v", query)
-		brokerResp, err := pinotClient.ExecutePQL(table, query)
-		if err != nil {
-			log.Error(err)
-		}
-		printBrokerResp(brokerResp)
-	}
 }
 
 func printBrokerResp(brokerResp *pinot.BrokerResponse) {

--- a/pinot/connection.go
+++ b/pinot/connection.go
@@ -27,21 +27,3 @@ func (c *Connection) ExecuteSQL(table string, query string) (*BrokerResponse, er
 	}
 	return brokerResp, err
 }
-
-// ExecutePQL for a given table
-func (c *Connection) ExecutePQL(table string, query string) (*BrokerResponse, error) {
-	brokerAddress, err := c.brokerSelector.selectBroker(table)
-	if err != nil {
-		log.Errorf("Unable to find an available broker for table %s, Error: %v\n", table, err)
-		return nil, err
-	}
-	brokerResp, err := c.transport.execute(brokerAddress, &Request{
-		queryFormat: "pql",
-		query:       query,
-	})
-	if err != nil {
-		log.Errorf("Caught exception to execute PQL query %s, Error: %v\n", query, err)
-		return nil, err
-	}
-	return brokerResp, err
-}

--- a/pinot/connection_test.go
+++ b/pinot/connection_test.go
@@ -52,54 +52,6 @@ func TestSendingSQLWithMockServer(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestSendingPQLWithMockServer(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		assert.Equal(t, "POST", r.Method)
-		assert.True(t, strings.HasSuffix(r.RequestURI, "/query"))
-		fmt.Fprintln(w, `{"aggregationResults":[{"groupByResult":[{"value":"4720","group":["CHN"]},{"value":"4621","group":["PHI"]},{"value":"4575","group":["PIT"]},{"value":"4535","group":["SLN"]},{"value":"4393","group":["CIN"]},{"value":"4318","group":["CLE"]},{"value":"4130","group":["BOS"]},{"value":"4111","group":["CHA"]},{"value":"4069","group":["NYA"]},{"value":"4051","group":["DET"]}],"function":"count_star","groupByColumns":["teamID"]},{"groupByResult":[{"value":"14859.00000","group":["NYA"]},{"value":"13202.00000","group":["CHN"]},{"value":"12854.00000","group":["DET"]},{"value":"12599.00000","group":["BOS"]},{"value":"12248.00000","group":["PHI"]},{"value":"12085.00000","group":["CIN"]},{"value":"12050.00000","group":["CLE"]},{"value":"10915.00000","group":["SLN"]},{"value":"10582.00000","group":["PIT"]},{"value":"10501.00000","group":["CHA"]}],"function":"sum_homeRuns","groupByColumns":["teamID"]}],"exceptions":[],"numServersQueried":1,"numServersResponded":1,"numSegmentsQueried":1,"numSegmentsProcessed":1,"numSegmentsMatched":1,"numConsumingSegmentsQueried":0,"numDocsScanned":97889,"numEntriesScannedInFilter":0,"numEntriesScannedPostFilter":195778,"numGroupsLimitReached":false,"totalDocs":97889,"timeUsedMs":7,"segmentStatistics":[],"traceInfo":{},"minConsumingFreshnessTimeMs":0}`)
-	}))
-	defer ts.Close()
-	pinotClient, err := NewFromBrokerList([]string{ts.URL})
-	assert.NotNil(t, pinotClient)
-	assert.NotNil(t, pinotClient.brokerSelector)
-	assert.NotNil(t, pinotClient.transport)
-	assert.Nil(t, err)
-	resp, err := pinotClient.ExecutePQL("", "select teamID, count(*) as cnt, sum(homeRuns) as sum_homeRuns from baseballStats group by teamID limit 10")
-	assert.NotNil(t, resp)
-	assert.Nil(t, err)
-
-	// Examine ResultTable
-	assert.Equal(t, 2, len(resp.AggregationResults))
-	assert.Equal(t, 10, len(resp.AggregationResults[0].GroupByResult))
-	assert.Equal(t, 1, len(resp.AggregationResults[0].GroupByResult[0].Group))
-	assert.Equal(t, "4720", resp.AggregationResults[0].GroupByResult[0].Value)
-	assert.Equal(t, "CHN", resp.AggregationResults[0].GroupByResult[0].Group[0])
-	assert.Equal(t, "count_star", resp.AggregationResults[0].Function)
-	assert.Equal(t, 1, len(resp.AggregationResults[0].GroupByColumns))
-	assert.Equal(t, "teamID", resp.AggregationResults[0].GroupByColumns[0])
-
-	assert.Equal(t, 10, len(resp.AggregationResults[1].GroupByResult))
-	assert.Equal(t, 1, len(resp.AggregationResults[1].GroupByResult[0].Group))
-	assert.Equal(t, "14859.00000", resp.AggregationResults[1].GroupByResult[0].Value)
-	assert.Equal(t, "NYA", resp.AggregationResults[1].GroupByResult[0].Group[0])
-	assert.Equal(t, "sum_homeRuns", resp.AggregationResults[1].Function)
-	assert.Equal(t, 1, len(resp.AggregationResults[1].GroupByColumns))
-	assert.Equal(t, "teamID", resp.AggregationResults[1].GroupByColumns[0])
-
-	badPinotClient := &Connection{
-		transport: &jsonAsyncHTTPClientTransport{
-			client: http.DefaultClient,
-		},
-		brokerSelector: &simpleBrokerSelector{
-			brokerList: []string{},
-		},
-	}
-	_, err = badPinotClient.ExecutePQL("", "")
-	assert.NotNil(t, err)
-}
-
 func TestSendingQueryWithErrorResponse(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
@@ -111,8 +63,6 @@ func TestSendingQueryWithErrorResponse(t *testing.T) {
 	assert.NotNil(t, pinotClient.transport)
 	assert.Nil(t, err)
 	_, err = pinotClient.ExecuteSQL("", "select teamID, count(*) as cnt, sum(homeRuns) as sum_homeRuns from baseballStats group by teamID limit 10")
-	assert.NotNil(t, err)
-	_, err = pinotClient.ExecutePQL("", "select teamID, count(*) as cnt, sum(homeRuns) as sum_homeRuns from baseballStats group by teamID limit 10")
 	assert.NotNil(t, err)
 }
 
@@ -129,9 +79,6 @@ func TestSendingQueryWithNonJsonResponse(t *testing.T) {
 	assert.NotNil(t, pinotClient.transport)
 	assert.Nil(t, err)
 	_, err = pinotClient.ExecuteSQL("", "select teamID, count(*) as cnt, sum(homeRuns) as sum_homeRuns from baseballStats group by teamID limit 10")
-	assert.NotNil(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "invalid character"))
-	_, err = pinotClient.ExecutePQL("", "select teamID, count(*) as cnt, sum(homeRuns) as sum_homeRuns from baseballStats group by teamID limit 10")
 	assert.NotNil(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), "invalid character"))
 }


### PR DESCRIPTION
Deprecate all the PQL methods usage following Pinot 0.11.0 release