### PR TITLE
Add HTTP timeout support for pinot query

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,26 @@ pinotClient, err := pinot.NewWithConfig(&pinot.ClientConfig{
 })
 ```
 
+### Add HTTP timeout for Pinot Queries
+
+By Default this client uses golang's default http timeout, which is "No TImeout". If you want pinot queries to timeout within given time, add `HTTPTimeout` in `ClientConfig`
+
+```
+pinotClient, err := pinot.NewWithConfig(&pinot.ClientConfig{
+	ZkConfig: &pinot.ZookeeperConfig{
+		ZookeeperPath:     zkPath,
+		PathPrefix:        strings.Join([]string{zkPathPrefix, pinotCluster}, "/"),
+		SessionTimeoutSec: defaultZkSessionTimeoutSec,
+	},
+	// additional header added to Broker Query API requests
+    ExtraHTTPHeader: map[string]string{
+        "extra-header":"value",
+    },
+	// optional HTTP timeout parameter for Pinot Queries.
+	HTTPTimeout: 300 * time.Millisecond,
+})
+```
+
 ## Query Pinot
 
 Please see this [example](https://github.com/startreedata/pinot-client-go/blob/master/examples/batch-quickstart/main.go) for your reference.

--- a/pinot/config.go
+++ b/pinot/config.go
@@ -1,10 +1,15 @@
 package pinot
 
+import "time"
+
 // ClientConfig configs to create a PinotDbConnection
 type ClientConfig struct {
 
 	// Additional HTTP headers to include in broker query API requests
 	ExtraHTTPHeader map[string]string
+
+	// HTTP request timeout in your broker query for API requests
+	HTTPTimeout time.Duration
 
 	// Zookeeper Configs
 	ZkConfig *ZookeeperConfig

--- a/pinot/connectionFactory.go
+++ b/pinot/connectionFactory.go
@@ -46,6 +46,12 @@ func NewWithConfig(config *ClientConfig) (*Connection, error) {
 		client: http.DefaultClient,
 		header: config.ExtraHTTPHeader,
 	}
+
+	// Set HTTPTimeout from config
+	if config.HTTPTimeout != 0 {
+		transport.client.Timeout = config.HTTPTimeout
+	}
+
 	var conn *Connection
 	if config.ZkConfig != nil {
 		conn = &Connection{

--- a/pinot/connectionFactory_test.go
+++ b/pinot/connectionFactory_test.go
@@ -39,7 +39,9 @@ func TestPinotClients(t *testing.T) {
 
 func TestPinotWithHttpTImeout(t *testing.T) {
 	pinotClient , err := NewWithConfig(&ClientConfig{
+		// Hit an unreachable port
 		BrokerList: []string{"www.google.com:81"},
+		// Set timeout to 1 sec
 		HTTPTimeout: 1 * time.Second,
 	})
 	assert.Nil(t,err)
@@ -48,5 +50,8 @@ func TestPinotWithHttpTImeout(t *testing.T) {
 	end := time.Since(start)
 	assert.NotNil(t,err)
 	diff := int(end.Seconds())
-	assert.Equal(t,1,diff)
+	// Query should ideally timeout in 1 sec, considering other variables,
+	// diff might not be exactly equal to 1. So, we can assert that diff 
+	// must be less than 2 sec. 
+	assert.Less(t,diff,2)
 }

--- a/pinot/connectionFactory_test.go
+++ b/pinot/connectionFactory_test.go
@@ -3,6 +3,7 @@ package pinot
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -34,4 +35,18 @@ func TestPinotClients(t *testing.T) {
 	_, err = NewWithConfig(&ClientConfig{})
 	assert.NotNil(t, err)
 	assert.True(t, strings.Contains(err.Error(), "please specify"))
+}
+
+func TestPinotWithHttpTImeout(t *testing.T) {
+	pinotClient , err := NewWithConfig(&ClientConfig{
+		BrokerList: []string{"www.google.com:81"},
+		HTTPTimeout: 1 * time.Second,
+	})
+	assert.Nil(t,err)
+	start := time.Now()
+	_ , err = pinotClient.ExecuteSQL("testTable","select * from testTable");
+	end := time.Since(start)
+	assert.NotNil(t,err)
+	diff := int(end.Seconds())
+	assert.Equal(t,1,diff)
 }


### PR DESCRIPTION
1. Currently Pinot uses default golang HTTP timeout, which is "No TImeout". Due to this, users of pinot go client have to implement timeout logic on their side, to avoid waiting for pinot query.
2. This PR aims to solve this by exposing HTTP Timeout parameter to the end user.

