### PR TITLE
feature: add trace switch in go client

### DIFF
--- a/pinot/connection.go
+++ b/pinot/connection.go
@@ -8,6 +8,7 @@ import (
 type Connection struct {
 	transport      clientTransport
 	brokerSelector brokerSelector
+	trace          bool
 }
 
 // ExecuteSQL for a given table
@@ -20,10 +21,19 @@ func (c *Connection) ExecuteSQL(table string, query string) (*BrokerResponse, er
 	brokerResp, err := c.transport.execute(brokerAddress, &Request{
 		queryFormat: "sql",
 		query:       query,
+		trace:       c.trace,
 	})
 	if err != nil {
 		log.Errorf("Caught exception to execute SQL query %s, Error: %v\n", query, err)
 		return nil, err
 	}
 	return brokerResp, err
+}
+
+func (c *Connection) OpenTrace() {
+	c.trace = true
+}
+
+func (c *Connection) CloseTrace() {
+	c.trace = false
 }

--- a/pinot/jsonAsyncHTTPClientTransport.go
+++ b/pinot/jsonAsyncHTTPClientTransport.go
@@ -30,6 +30,9 @@ func (t jsonAsyncHTTPClientTransport) execute(brokerAddress string, query *Reque
 	if query.queryFormat == "sql" {
 		requestJSON["queryOptions"] = "groupByMode=sql;responseFormat=sql"
 	}
+	if query.trace {
+		requestJSON["trace"] = "true"
+	}
 	jsonValue, _ := json.Marshal(requestJSON)
 	req, err := createHTTPRequest(url, jsonValue, t.header)
 	if err != nil {

--- a/pinot/jsonAsyncHTTPClientTransport_test.go
+++ b/pinot/jsonAsyncHTTPClientTransport_test.go
@@ -25,6 +25,14 @@ func TestCreateHTTPRequest(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestCreateHTTPRequestWithTrace(t *testing.T) {
+	r, err := createHTTPRequest("localhost:8000", []byte(`{"sql": "select * from baseballStats limit 10", "trace": "true"}`), map[string]string{"a": "b"})
+	assert.Nil(t, err)
+	assert.Equal(t, "POST", r.Method)
+	_, err = createHTTPRequest("localhos\t:8000", []byte(`{"sql": "select * from baseballStats limit 10", "trace": "true"}`), map[string]string{"a": "b"})
+	assert.NotNil(t, err)
+}
+
 func TestJsonAsyncHTTPClientTransport(t *testing.T) {
 	transport := &jsonAsyncHTTPClientTransport{
 		client: http.DefaultClient,

--- a/pinot/request.go
+++ b/pinot/request.go
@@ -4,4 +4,5 @@ package pinot
 type Request struct {
 	queryFormat string
 	query       string
+	trace       bool
 }


### PR DESCRIPTION
Add trace in request for broker response. 

fix issue #10 