### PR TITLE
Sorted structs as per fieldalignment and added lint for further checking.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,32 @@
+run:
+  # Allow multiple parallel golangci-lint instances running.
+  # If false (default) - golangci-lint acquires file lock on start.
+  allow-parallel-runners: true
+
+output:
+  # sorts results by: filepath, line and column
+  sort-results: true
+
+linters:
+  enable:
+    - godox
+    - govet
+    - whitespace
+
+  disable:
+    - ineffassign
+    - errcheck
+    - staticcheck
+    - gosimple
+    - stylecheck
+    - wsl
+    - revive
+
+linter-settings:
+  govet:
+    # report about shadowed variables
+    check-shadowing: true
+
+    # enable or disable analyzers by name
+    # run `go tool vet help` to see all analyzers
+    enable-all: true

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ setup: install-covertools install-deps
 lint:
 	go fmt ./...
 	go vet ./...
+	golangci-lint run
 
 .PHONY: build
 build:

--- a/pinot/config.go
+++ b/pinot/config.go
@@ -4,36 +4,31 @@ import "time"
 
 // ClientConfig configs to create a PinotDbConnection
 type ClientConfig struct {
-
 	// Additional HTTP headers to include in broker query API requests
 	ExtraHTTPHeader map[string]string
-
-	// HTTP request timeout in your broker query for API requests
-	HTTPTimeout time.Duration
-
 	// Zookeeper Configs
 	ZkConfig *ZookeeperConfig
-
-	// BrokerList
-	BrokerList []string
-
 	// Controller Config
 	ControllerConfig *ControllerConfig
+	// BrokerList
+	BrokerList []string
+	// HTTP request timeout in your broker query for API requests
+	HTTPTimeout time.Duration
 }
 
 // ZookeeperConfig describes how to config Pinot Zookeeper connection
 type ZookeeperConfig struct {
-	ZookeeperPath     []string
 	PathPrefix        string
+	ZookeeperPath     []string
 	SessionTimeoutSec int
 }
 
 // ControllerConfig describes connection of a controller-based selector that
 // periodically fetches table-to-broker mapping via the controller API
 type ControllerConfig struct {
-	ControllerAddress string
-	// Frequency of broker data refresh in milliseconds via controller API - defaults to 1000ms
-	UpdateFreqMs int
 	// Additional HTTP headers to include in the controller API request
 	ExtraControllerAPIHeaders map[string]string
+	ControllerAddress         string
+	// Frequency of broker data refresh in milliseconds via controller API - defaults to 1000ms
+	UpdateFreqMs int
 }

--- a/pinot/connectionFactory.go
+++ b/pinot/connectionFactory.go
@@ -79,7 +79,10 @@ func NewWithConfig(config *ClientConfig) (*Connection, error) {
 		}
 	}
 	if conn != nil {
-		conn.brokerSelector.init()
+		err := conn.brokerSelector.init()
+		if err != nil {
+			return nil, err
+		}
 		return conn, nil
 	}
 	return nil, fmt.Errorf(

--- a/pinot/controllerBasedBrokerSelector.go
+++ b/pinot/controllerBasedBrokerSelector.go
@@ -26,10 +26,10 @@ type HTTPClient interface {
 }
 
 type controllerBasedSelector struct {
-	tableAwareBrokerSelector
-	controllerAPIReqUrl string
-	config              *ControllerConfig
 	client              HTTPClient
+	config              *ControllerConfig
+	controllerAPIReqUrl string
+	tableAwareBrokerSelector
 }
 
 func (s *controllerBasedSelector) init() error {

--- a/pinot/controllerBasedBrokerSelector.go
+++ b/pinot/controllerBasedBrokerSelector.go
@@ -2,7 +2,7 @@ package pinot
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -118,7 +118,7 @@ func (s *controllerBasedSelector) updateBrokerData() error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("An error occurred when reading controller API response: %v", err)
 		}

--- a/pinot/controllerBasedBrokerSelector_test.go
+++ b/pinot/controllerBasedBrokerSelector_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 type MockHTTPClientSuccess struct {
-	statusCode int
 	body       io.ReadCloser
+	statusCode int
 }
 
 func (m *MockHTTPClientSuccess) Do(req *http.Request) (*http.Response, error) {

--- a/pinot/controllerResponse.go
+++ b/pinot/controllerResponse.go
@@ -6,9 +6,9 @@ import (
 )
 
 type brokerDto struct {
-	Port         int    `json:"port"`
 	Host         string `json:"host"`
 	InstanceName string `json:"instanceName"`
+	Port         int    `json:"port"`
 }
 
 type controllerResponse map[string]([]brokerDto)

--- a/pinot/dynamicBrokerSelector.go
+++ b/pinot/dynamicBrokerSelector.go
@@ -19,19 +19,19 @@ const (
 type ReadZNode func(path string) ([]byte, error)
 
 type dynamicBrokerSelector struct {
-	tableAwareBrokerSelector
 	zkConfig               *ZookeeperConfig
 	zkConn                 *zk.Conn
 	externalViewZnodeWatch <-chan zk.Event
 	readZNode              ReadZNode
 	externalViewZkPath     string
+	tableAwareBrokerSelector
 }
 
 type externalView struct {
-	ID           string                         `json:"id"`
 	SimpleFields map[string]string              `json:"simpleFields"`
 	MapFields    map[string](map[string]string) `json:"mapFields"`
 	ListFields   map[string]([]string)          `json:"listFields"`
+	ID           string                         `json:"id"`
 }
 
 func (s *dynamicBrokerSelector) init() error {

--- a/pinot/dynamicBrokerSelector_test.go
+++ b/pinot/dynamicBrokerSelector_test.go
@@ -33,7 +33,7 @@ func TestExtractBrokerHostPort(t *testing.T) {
 func TestErrorInit(t *testing.T) {
 	selector := &dynamicBrokerSelector{
 		tableAwareBrokerSelector: tableAwareBrokerSelector{
-			tableBrokerMap: map[string]([]string){"myTable": []string{}},
+			tableBrokerMap: map[string][]string{"myTable": []string{}},
 		},
 		zkConfig: &ZookeeperConfig{
 			ZookeeperPath: []string{},
@@ -46,7 +46,7 @@ func TestErrorInit(t *testing.T) {
 func TestErrorRefreshExternalView(t *testing.T) {
 	selector := &dynamicBrokerSelector{
 		tableAwareBrokerSelector: tableAwareBrokerSelector{
-			tableBrokerMap: map[string]([]string){"myTable": []string{}},
+			tableBrokerMap: map[string][]string{"myTable": []string{}},
 		},
 		zkConfig: &ZookeeperConfig{
 			ZookeeperPath: []string{},

--- a/pinot/jsonAsyncHTTPClientTransport.go
+++ b/pinot/jsonAsyncHTTPClientTransport.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 
@@ -45,7 +45,7 @@ func (t jsonAsyncHTTPClientTransport) execute(brokerAddress string, query *Reque
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusOK {
-		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Error("Unable to read Pinot response. ", err)
 			return nil, err

--- a/pinot/response.go
+++ b/pinot/response.go
@@ -4,24 +4,24 @@ import "encoding/json"
 
 // BrokerResponse is the data structure for broker response.
 type BrokerResponse struct {
-	AggregationResults          []*AggregationResult `json:"aggregationResults,omitempty"`
 	SelectionResults            *SelectionResults    `json:"SelectionResults,omitempty"`
 	ResultTable                 *ResultTable         `json:"resultTable,omitempty"`
-	Exceptions                  []Exception          `json:"exceptions"`
 	TraceInfo                   map[string]string    `json:"traceInfo,omitempty"`
-	NumServersQueried           int                  `json:"numServersQueried"`
+	AggregationResults          []*AggregationResult `json:"aggregationResults,omitempty"`
+	Exceptions                  []Exception          `json:"exceptions"`
+	NumSegmentsProcessed        int                  `json:"numSegmentsProcessed"`
 	NumServersResponded         int                  `json:"numServersResponded"`
 	NumSegmentsQueried          int                  `json:"numSegmentsQueried"`
-	NumSegmentsProcessed        int                  `json:"numSegmentsProcessed"`
+	NumServersQueried           int                  `json:"numServersQueried"`
 	NumSegmentsMatched          int                  `json:"numSegmentsMatched"`
 	NumConsumingSegmentsQueried int                  `json:"numConsumingSegmentsQueried"`
 	NumDocsScanned              int64                `json:"numDocsScanned"`
 	NumEntriesScannedInFilter   int64                `json:"numEntriesScannedInFilter"`
 	NumEntriesScannedPostFilter int64                `json:"numEntriesScannedPostFilter"`
-	NumGroupsLimitReached       bool                 `json:"numGroupsLimitReached"`
 	TotalDocs                   int64                `json:"totalDocs"`
 	TimeUsedMs                  int                  `json:"timeUsedMs"`
 	MinConsumingFreshnessTimeMs int64                `json:"minConsumingFreshnessTimeMs"`
+	NumGroupsLimitReached       bool                 `json:"numGroupsLimitReached"`
 }
 
 // AggregationResult is the data structure for PQL aggregation result
@@ -52,8 +52,8 @@ type RespSchema struct {
 
 // Exception is Pinot exceptions.
 type Exception struct {
-	ErrorCode int    `json:"errorCode"`
 	Message   string `json:"message"`
+	ErrorCode int    `json:"errorCode"`
 }
 
 // ResultTable is a ResultTable

--- a/pinot/response_test.go
+++ b/pinot/response_test.go
@@ -41,7 +41,6 @@ func TestSqlSelectionQueryResponse(t *testing.T) {
 		assert.Equal(t, expectedColumnNames[i], brokerResponse.ResultTable.GetColumnName(i))
 		assert.Equal(t, expectedColumnTypes[i], brokerResponse.ResultTable.GetColumnDataType(i))
 	}
-
 }
 
 func TestSqlAggregationQueryResponse(t *testing.T) {

--- a/pinot/simplebrokerselector_test.go
+++ b/pinot/simplebrokerselector_test.go
@@ -26,7 +26,6 @@ func TestSimpleBrokerSelector(t *testing.T) {
 		assert.Equal(t, "broker", brokerName[0:6])
 		assert.Nil(t, err)
 	}
-
 }
 
 func TestWithEmptyBrokerList(t *testing.T) {

--- a/pinot/tableAwareBrokerSelector_test.go
+++ b/pinot/tableAwareBrokerSelector_test.go
@@ -14,7 +14,7 @@ func TestExtractTableName(t *testing.T) {
 
 func TestSelectBroker(t *testing.T) {
 	selector := &tableAwareBrokerSelector{
-		tableBrokerMap: map[string]([]string){"myTable": []string{"localhost:8000"}},
+		tableBrokerMap: map[string][]string{"myTable": []string{"localhost:8000"}},
 		allBrokerList:  []string{"localhost:8000"},
 	}
 	broker, err := selector.selectBroker("")
@@ -29,7 +29,7 @@ func TestSelectBroker(t *testing.T) {
 
 func TestErrorSelectBroker(t *testing.T) {
 	emptySelector := &tableAwareBrokerSelector{
-		tableBrokerMap: map[string]([]string){"myTable": []string{}},
+		tableBrokerMap: map[string][]string{"myTable": []string{}},
 	}
 	_, err := emptySelector.selectBroker("")
 	assert.NotNil(t, err)


### PR DESCRIPTION
- Sorted structs as per the `fieldalginment` following the command
   ```bash
    fieldalignment -fix github.com/startreedata/pinot-client-go/pinot 
   ```
- Added lint for further restricting the unsorted structs.
- Fixed couple of minor lint issues.
- added a couple of more linters for static analysis of code. some are disabled right now and in following PR, going to fix it. 