### PR TITLE
fix linter

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,24 +17,24 @@ jobs:
     runs-on: ubuntu-latest
     name: Linter
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: 1.19
           cache: false
 
       - name: Linter
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
 
   unit-tests:
     runs-on: ubuntu-latest
     name: Unit Tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.19
 
@@ -65,10 +65,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Integration Tests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.19
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,8 @@ linters:
     - gochecknoglobals
 
 linters-settings:
-  govet:
+  shadow:
+    enable: true
     # report about shadowed variables
     check-shadowing: true
 

--- a/pinot/connection_test.go
+++ b/pinot/connection_test.go
@@ -54,7 +54,7 @@ func TestSendingSQLWithMockServer(t *testing.T) {
 }
 
 func TestSendingQueryWithErrorResponse(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 	}))
 	defer ts.Close()
@@ -68,7 +68,7 @@ func TestSendingQueryWithErrorResponse(t *testing.T) {
 }
 
 func TestSendingQueryWithNonJsonResponse(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		fmt.Fprintln(w, `ProcessingException`)
@@ -111,7 +111,7 @@ func TestConnectionWithControllerBasedBrokerSelector(t *testing.T) {
 }
 
 func TestSendingQueryWithTraceOpen(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		var request map[string]string
 		err := json.NewDecoder(r.Body).Decode(&request)
 		assert.Equal(t, request["trace"], "true")
@@ -130,7 +130,7 @@ func TestSendingQueryWithTraceOpen(t *testing.T) {
 }
 
 func TestSendingQueryWithTraceClose(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		var request map[string]string
 		err := json.NewDecoder(r.Body).Decode(&request)
 		assert.Nil(t, err)

--- a/pinot/dynamicBrokerSelector.go
+++ b/pinot/dynamicBrokerSelector.go
@@ -42,7 +42,7 @@ func (s *dynamicBrokerSelector) init() error {
 		log.Errorf("Failed to connect to zookeeper: %v\n", s.zkConfig.ZookeeperPath)
 		return err
 	}
-	s.readZNode = func(path string) ([]byte, error) {
+	s.readZNode = func(_ string) ([]byte, error) {
 		node, _, err2 := s.zkConn.Get(s.externalViewZkPath)
 		if err2 != nil {
 			log.Errorf("Failed to read zk: %s, ExternalView path: %s\n", s.zkConfig.ZookeeperPath, s.externalViewZkPath)

--- a/pinot/dynamicBrokerSelector_test.go
+++ b/pinot/dynamicBrokerSelector_test.go
@@ -87,7 +87,7 @@ func TestErrorExternalViewUpdate(t *testing.T) {
 func TestMockReadZNode(t *testing.T) {
 	evBytes := []byte(`{"id":"brokerResource","simpleFields":{"BATCH_MESSAGE_MODE":"false","BUCKET_SIZE":"0","IDEAL_STATE_MODE":"CUSTOMIZED","NUM_PARTITIONS":"1","REBALANCE_MODE":"CUSTOMIZED","REPLICAS":"0","STATE_MODEL_DEF_REF":"BrokerResourceOnlineOfflineStateModel","STATE_MODEL_FACTORY_NAME":"DEFAULT"},"mapFields":{"baseballStats_OFFLINE":{"Broker_127.0.0.1_8000":"ONLINE", "Broker_127.0.0.1_9000":"ONLINE"}},"listFields":{}}`)
 	selector := &dynamicBrokerSelector{
-		readZNode: func(path string) ([]byte, error) {
+		readZNode: func(_ string) ([]byte, error) {
 			return evBytes, nil
 		},
 	}
@@ -115,7 +115,7 @@ func TestMockReadZNode(t *testing.T) {
 	evBytes = []byte(`abc`)
 	err = selector.refreshExternalView()
 	assert.NotNil(t, err)
-	selector.readZNode = func(path string) ([]byte, error) {
+	selector.readZNode = func(_ string) ([]byte, error) {
 		return nil, fmt.Errorf("erroReadZNode")
 	}
 	err = selector.refreshExternalView()
@@ -126,7 +126,7 @@ func TestMockUpdateEvent(t *testing.T) {
 	evBytes := []byte(`{"id":"brokerResource","simpleFields":{"BATCH_MESSAGE_MODE":"false","BUCKET_SIZE":"0","IDEAL_STATE_MODE":"CUSTOMIZED","NUM_PARTITIONS":"1","REBALANCE_MODE":"CUSTOMIZED","REPLICAS":"0","STATE_MODEL_DEF_REF":"BrokerResourceOnlineOfflineStateModel","STATE_MODEL_FACTORY_NAME":"DEFAULT"},"mapFields":{"baseballStats_OFFLINE":{"Broker_127.0.0.1_8000":"ONLINE", "Broker_127.0.0.1_9000":"ONLINE"}},"listFields":{}}`)
 	ch := make(chan zk.Event)
 	selector := &dynamicBrokerSelector{
-		readZNode: func(path string) ([]byte, error) {
+		readZNode: func(_ string) ([]byte, error) {
 			return evBytes, nil
 		},
 		externalViewZnodeWatch: ch,
@@ -162,7 +162,7 @@ func TestMockUpdateEvent(t *testing.T) {
 	evBytes = []byte(`abc`)
 	err = selector.refreshExternalView()
 	assert.NotNil(t, err)
-	selector.readZNode = func(path string) ([]byte, error) {
+	selector.readZNode = func(_ string) ([]byte, error) {
 		return nil, fmt.Errorf("erroReadZNode")
 	}
 	err = selector.refreshExternalView()


### PR DESCRIPTION
Fixing the below issue reported by the linter.
```
level=warning msg="[config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`."
```