### PR TITLE
escape string params

### DIFF
--- a/pinot/connection.go
+++ b/pinot/connection.go
@@ -83,7 +83,7 @@ func formatArg(value interface{}) (string, error) {
 		// For pinot type - STRING - enclose in single quotes
 		return escapeStringValue(v), nil
 	case *big.Int, *big.Float:
-		// For pinot types - STRING, BIG_DECIMAL and BYTES - enclose in single quotes
+		// For pinot types - BIG_DECIMAL and BYTES - enclose in single quotes
 		return fmt.Sprintf("'%v'", v), nil
 	case []byte:
 		// For pinot type - BYTES - convert to Hex string and enclose in single quotes

--- a/pinot/connection.go
+++ b/pinot/connection.go
@@ -79,7 +79,10 @@ func formatQuery(queryPattern string, params []interface{}) (string, error) {
 
 func formatArg(value interface{}) (string, error) {
 	switch v := value.(type) {
-	case string, *big.Int, *big.Float:
+	case string:
+		// For pinot type - STRING - enclose in single quotes
+		return escapeStringValue(v), nil
+	case *big.Int, *big.Float:
 		// For pinot types - STRING, BIG_DECIMAL and BYTES - enclose in single quotes
 		return fmt.Sprintf("'%v'", v), nil
 	case []byte:
@@ -96,6 +99,10 @@ func formatArg(value interface{}) (string, error) {
 		// Throw error for unsupported types
 		return "", fmt.Errorf("unsupported type: %T", v)
 	}
+}
+
+func escapeStringValue(s string) string {
+	return fmt.Sprintf("'%s'", strings.ReplaceAll(s, "'", "''"))
 }
 
 // OpenTrace for the connection

--- a/pinot/connection_test.go
+++ b/pinot/connection_test.go
@@ -186,6 +186,14 @@ func TestFormatQuery(t *testing.T) {
 	actualQuery, err = formatQuery(queryPattern, params)
 	assert.NotNil(t, err)
 	assert.Equal(t, expectedQuery, actualQuery)
+
+	// Test case 5: String parameter with single quote
+	queryPattern = "SELECT * FROM table WHERE name = ?"
+	params = []interface{}{"John's"}
+	expectedQuery = "SELECT * FROM table WHERE name = 'John''s'"
+	actualQuery, err = formatQuery(queryPattern, params)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedQuery, actualQuery)
 }
 
 func TestFormatArg(t *testing.T) {


### PR DESCRIPTION
otherwise query fails with 
```
org.apache.pinot.sql.parsers.CalciteSqlParser.compileToSqlNodeAndOptions(CalciteSqlParser.java:120)\
\  at org.apache.pinot.common.utils.request.RequestUtils.parseQuery(RequestUtils.java:73)\
\  at org.apache.pinot.broker.api.resources.PinotClientRequest.executeSqlQuery(PinotClientRequest.java:303)\
\  at org.apache.pinot.broker.api.resources.PinotClientRequest.executeSqlQuery(PinotClientRequest.java:294)\
...\
Caused by: org.apache.pinot.sql.parsers.parser.ParseException: Encountered \\" <IDENTIFIER> \\"Ivoire \\"\\" at line 1, column 885.\
Was expecting one of:\
    <QUOTED_STRING> ...\
    \\")\\" ...\
    <QUOTED_STRING> ...""
```
for string like `Cote d'Ivoire`