### PR TITLE
avoid logging in driver rather return err to application

### DIFF
--- a/pinot/connection.go
+++ b/pinot/connection.go
@@ -5,8 +5,6 @@ import (
 	"math/big"
 	"strings"
 	"time"
-
-	log "github.com/sirupsen/logrus"
 )
 
 // Connection to Pinot, normally created through calls to the {@link ConnectionFactory}.
@@ -26,8 +24,7 @@ func (c *Connection) UseMultistageEngine(useMultistageEngine bool) {
 func (c *Connection) ExecuteSQL(table string, query string) (*BrokerResponse, error) {
 	brokerAddress, err := c.brokerSelector.selectBroker(table)
 	if err != nil {
-		log.Errorf("Unable to find an available broker for table %s, Error: %v\n", table, err)
-		return nil, err
+		return nil, fmt.Errorf("unable to find an available broker for table %s, Error: %v", table, err)
 	}
 	brokerResp, err := c.transport.execute(brokerAddress, &Request{
 		queryFormat:         "sql",
@@ -36,8 +33,7 @@ func (c *Connection) ExecuteSQL(table string, query string) (*BrokerResponse, er
 		useMultistageEngine: c.useMultistageEngine,
 	})
 	if err != nil {
-		log.Errorf("Caught exception to execute SQL query %s, Error: %v\n", query, err)
-		return nil, err
+		return nil, fmt.Errorf("caught exception to execute SQL query %s, Error: %v", query, err)
 	}
 	return brokerResp, err
 }
@@ -46,7 +42,6 @@ func (c *Connection) ExecuteSQL(table string, query string) (*BrokerResponse, er
 func (c *Connection) ExecuteSQLWithParams(table string, queryPattern string, params []interface{}) (*BrokerResponse, error) {
 	query, err := formatQuery(queryPattern, params)
 	if err != nil {
-		log.Errorf("Failed to format query: %v\n", err)
 		return nil, fmt.Errorf("failed to format query: %v", err)
 	}
 	return c.ExecuteSQL(table, query)
@@ -67,7 +62,6 @@ func formatQuery(queryPattern string, params []interface{}) (string, error) {
 		newQuery.WriteString(part)
 		formattedParam, err := formatArg(params[i])
 		if err != nil {
-			log.Errorf("Failed to format parameter: %v\n", err)
 			return "", fmt.Errorf("failed to format parameter: %v", err)
 		}
 		newQuery.WriteString(formattedParam)

--- a/pinot/connectionFactory.go
+++ b/pinot/connectionFactory.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-
-	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -106,8 +104,7 @@ func NewWithConfigAndClient(config *ClientConfig, httpClient *http.Client) (*Con
 	if conn != nil {
 		// TODO: error handling results into `make test` failure.
 		if err := conn.brokerSelector.init(); err != nil {
-			log.Errorf("Failed to initialize broker selector: %v", err)
-			return conn, err
+			return conn, fmt.Errorf("failed to initialize broker selector: %v", err)
 		}
 		return conn, nil
 	}

--- a/pinot/connection_test.go
+++ b/pinot/connection_test.go
@@ -85,7 +85,7 @@ func TestSendingQueryWithNonJsonResponse(t *testing.T) {
 	assert.Nil(t, err)
 	_, err = pinotClient.ExecuteSQL("", "select teamID, count(*) as cnt, sum(homeRuns) as sum_homeRuns from baseballStats group by teamID limit 10")
 	assert.NotNil(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "invalid character"))
+	assert.True(t, strings.Contains(err.Error(), "invalid character"))
 }
 
 func TestConnectionWithControllerBasedBrokerSelector(t *testing.T) {
@@ -333,7 +333,7 @@ func TestExecuteSQLWithParams(t *testing.T) {
 	_, err = conn.ExecuteSQLWithParams("baseballStats2", queryPattern, params)
 
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "error selecting broker")
+	assert.ErrorContains(t, err, "error selecting broker")
 
 	// Test case 3: Error in formatting query
 	mockBrokerSelector.On("selectBroker", "baseballStats3").Return("host2:8000", nil)
@@ -342,7 +342,7 @@ func TestExecuteSQLWithParams(t *testing.T) {
 	_, err = conn.ExecuteSQLWithParams("baseballStats3", queryPattern, params)
 
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "error executing query")
+	assert.ErrorContains(t, err, "error executing query")
 
 	// Test case 4: Error in formatting query with mismatched number of parameters
 	queryPattern = "SELECT * FROM table WHERE id = ? AND name = ?"

--- a/pinot/controllerBasedBrokerSelector.go
+++ b/pinot/controllerBasedBrokerSelector.go
@@ -40,13 +40,11 @@ func (s *controllerBasedSelector) init() error {
 	var err error
 	s.controllerAPIReqURL, err = getControllerRequestURL(s.config.ControllerAddress)
 	if err != nil {
-		log.Errorf("An error occurred when parsing controller address: %v", err)
-		return err
+		return fmt.Errorf("an error occurred when parsing controller address: %v", err)
 	}
 
 	if err = s.updateBrokerData(); err != nil {
-		log.Errorf("An error occurred when fetching broker data from controller API for the first time, Error: %v", err)
-		return err
+		return fmt.Errorf("an error occurred when fetching broker data from controller API: %v", err)
 	}
 	go s.setupInterval()
 	return nil

--- a/pinot/jsonAsyncHTTPClientTransport.go
+++ b/pinot/jsonAsyncHTTPClientTransport.go
@@ -54,8 +54,7 @@ func (t jsonAsyncHTTPClientTransport) execute(brokerAddress string, query *Reque
 	}
 	resp, err := t.client.Do(req)
 	if err != nil {
-		log.Error("Got exceptions during sending request. ", err)
-		return nil, err
+		return nil, fmt.Errorf("got exceptions during sending request. %v", err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -65,13 +64,11 @@ func (t jsonAsyncHTTPClientTransport) execute(brokerAddress string, query *Reque
 	if resp.StatusCode == http.StatusOK {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			log.Error("Unable to read Pinot response. ", err)
-			return nil, err
+			return nil, fmt.Errorf("unable to read Pinot response. %v", err)
 		}
 		var brokerResponse BrokerResponse
 		if err = decodeJSONWithNumber(bodyBytes, &brokerResponse); err != nil {
-			log.Error("Unable to unmarshal json response to a brokerResponse structure. ", err)
-			return nil, err
+			return nil, fmt.Errorf("unable to unmarshal json response to a brokerResponse structure. %v", err)
 		}
 		return &brokerResponse, nil
 	}
@@ -94,8 +91,7 @@ func getQueryTemplate(queryFormat string, brokerAddress string) string {
 func createHTTPRequest(url string, jsonValue []byte, extraHeader map[string]string) (*http.Request, error) {
 	r, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonValue))
 	if err != nil {
-		log.Error("Invalid HTTP Request", err)
-		return nil, err
+		return nil, fmt.Errorf("invalid HTTP request: %v", err)
 	}
 	for k, v := range defaultHTTPHeader {
 		r.Header.Add(k, v)

--- a/pinot/jsonAsyncHTTPClientTransport_test.go
+++ b/pinot/jsonAsyncHTTPClientTransport_test.go
@@ -43,7 +43,7 @@ func TestJsonAsyncHTTPClientTransport(t *testing.T) {
 		query:       "select * from baseballStats limit 10",
 	})
 	assert.NotNil(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "parse "))
+	assert.True(t, strings.Contains(err.Error(), "parse "))
 
 	_, err = transport.execute("randomhost", &Request{
 		queryFormat: "sql",
@@ -57,5 +57,5 @@ func TestJsonAsyncHTTPClientTransport(t *testing.T) {
 		useMultistageEngine: true,
 	})
 	assert.NotNil(t, err)
-	assert.True(t, strings.HasPrefix(err.Error(), "Post "))
+	assert.True(t, strings.Contains(err.Error(), "Post "))
 }


### PR DESCRIPTION
Avoid logging errors directly in driver but rather return to the application. For example, we use structured logging in our application however we do get plain text logs as pinot driver logs them as it is. So if possible avoid it.