### PR TITLE
propagating underlying http/net errors

### DIFF
--- a/pinot/connection.go
+++ b/pinot/connection.go
@@ -33,7 +33,7 @@ func (c *Connection) ExecuteSQL(table string, query string) (*BrokerResponse, er
 		useMultistageEngine: c.useMultistageEngine,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("caught exception to execute SQL query %s, Error: %v", query, err)
+		return nil, fmt.Errorf("caught exception to execute SQL query %s, Error: %w", query, err)
 	}
 	return brokerResp, err
 }

--- a/pinot/jsonAsyncHTTPClientTransport.go
+++ b/pinot/jsonAsyncHTTPClientTransport.go
@@ -65,7 +65,7 @@ func (t jsonAsyncHTTPClientTransport) execute(brokerAddress string, query *Reque
 	}
 	resp, err := t.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("got exceptions during sending request. %v", err)
+		return nil, fmt.Errorf("got exceptions during sending request. %w", err)
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -75,7 +75,7 @@ func (t jsonAsyncHTTPClientTransport) execute(brokerAddress string, query *Reque
 	if resp.StatusCode == http.StatusOK {
 		bodyBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, fmt.Errorf("unable to read Pinot response. %v", err)
+			return nil, fmt.Errorf("unable to read Pinot response. %w", err)
 		}
 		var brokerResponse BrokerResponse
 		if err = decodeJSONWithNumber(bodyBytes, &brokerResponse); err != nil {
@@ -102,7 +102,7 @@ func getQueryTemplate(queryFormat string, brokerAddress string) string {
 func createHTTPRequest(url string, jsonValue []byte, extraHeader map[string]string) (*http.Request, error) {
 	r, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonValue))
 	if err != nil {
-		return nil, fmt.Errorf("invalid HTTP request: %v", err)
+		return nil, fmt.Errorf("invalid HTTP request: %w", err)
 	}
 	for k, v := range defaultHTTPHeader {
 		r.Header.Add(k, v)


### PR DESCRIPTION
Underlying error was not propagating so it hard for client to retry https/net error.