### PR TITLE
Revert "write timestamp args as millis (#47)"

### DIFF
--- a/pinot/connection.go
+++ b/pinot/connection.go
@@ -84,8 +84,8 @@ func formatArg(value interface{}) (string, error) {
 		hexString := fmt.Sprintf("%x", v)
 		return fmt.Sprintf("'%s'", hexString), nil
 	case time.Time:
-		// For pinot type - TIMESTAMP - write as milliseconds since epoch
-		return fmt.Sprintf("%d", v.UnixMilli()), nil
+		// For pinot type - TIMESTAMP - convert to ISO8601 format and enclose in single quotes
+		return fmt.Sprintf("'%s'", v.Format("2006-01-02 15:04:05.000")), nil
 	case int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64, bool:
 		// For types - INT, LONG, FLOAT, DOUBLE and BOOLEAN use as-is
 		return fmt.Sprintf("%v", v), nil

--- a/pinot/connection_test.go
+++ b/pinot/connection_test.go
@@ -210,7 +210,7 @@ func TestFormatArg(t *testing.T) {
 
 	// Test case 2: time.Time value
 	value2 := time.Date(2022, time.January, 1, 12, 0, 0, 0, time.UTC)
-	expected2 := "1641038400000"
+	expected2 := "'2022-01-01 12:00:00.000'"
 	actual2, err := formatArg(value2)
 	assert.Nil(t, err)
 	assert.Equal(t, expected2, actual2)


### PR DESCRIPTION
This reverts commit a58dcf09d76decfd237e5f7845e3475c00159bd4. Context here - https://github.com/startreedata/pinot-client-go/pull/47/files#r2183709320